### PR TITLE
fix: improve error message

### DIFF
--- a/src/e2e.spec.js
+++ b/src/e2e.spec.js
@@ -173,7 +173,7 @@ describe('CLI', () => {
       expect(result).toMatchInlineSnapshot(`
         "[33mwarn[39m: Ignore (no x-examples parameters) - GET /posts/{id} 200
         [33mwarn[39m: Ignore (no x-examples parameters) - GET /posts/{id} 404
-        [31merror[39m: An x-examples parameter for \\"userId\\" is missing from /posts.responses.200.x-examples.default.parameters[1]
+        [31merror[39m: An x-examples parameter for \\"userId\\" is missing from /posts.get.responses.200.x-examples.default.parameters[1]
         "
       `);
     });

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,6 +11,7 @@ const EXAMPLE_PROP_NAME = 'x-examples';
 const IGNORE_PROPERTY_PROP_NAME = 'x-test-ignore-paths';
 const IGNORE_ENDPOINT_NAME = 'x-ignore';
 const MOCK_FILE_PROP = 'x-mock-file';
+const MISSING_PARAM_ERROR_MESSAGE = 'Missing parameter object!';
 
 // Returns fetch config for calling all the endpoints
 function getFetchConfigForAPIEndpoints(params) {
@@ -253,9 +254,13 @@ async function resolveFetchConfigParams(params) {
         fconfig.resolvedParams = fconfig.resolvedParams || [];
         fconfig.resolvedParams[index] = paramValue;
       } catch (err) {
-        throw new Error(
-          `An ${EXAMPLE_PROP_NAME} parameter for "${paramName}" is missing from ${fconfig.path}.responses.${fconfig.expectedStatusCode}.${EXAMPLE_PROP_NAME}.${fconfig.exampleName}.parameters[${index}]`,
-        );
+        if (err.message === MISSING_PARAM_ERROR_MESSAGE) {
+          throw new Error(
+            `An ${EXAMPLE_PROP_NAME} parameter for "${paramName}" is missing from ${fconfig.path}.${fconfig.config.method}.responses.${fconfig.expectedStatusCode}.${EXAMPLE_PROP_NAME}.${fconfig.exampleName}.parameters[${index}]`,
+          );
+        }
+        // re-throw the error otherwise.
+        throw err;
       }
     }),
   );
@@ -276,7 +281,7 @@ async function resolveFetchConfigParams(params) {
 
 function getParamValue(serverUrl, inputObj, absSpecFilePath) {
   if (!inputObj) {
-    throw new Error(`Missing parameter object!`);
+    throw new Error(MISSING_PARAM_ERROR_MESSAGE);
   }
   if (inputObj.script !== undefined) {
     // TODO: The script MUST be relative to the spec file!


### PR DESCRIPTION
- add missing response-verb from error message
- only show this error message if the exception is caused by a missing parameter object